### PR TITLE
ci/create-android-dockerfile-and-initial-jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,22 @@
+pipeline {
+    agent {
+        dockerfile {
+            filename 'Dockerfile'
+            dir 'tools/dockers/android-sdk'
+            args '-u root:root' //todo here because gradlew needs to access root folder /opt
+        }
+    }
+    stages {
+        stage("Assemble") {
+            steps {
+                sh "./gradlew clean assembleDebug"
+            }
+        }
+        //todo here because we are overriding jenkins user with container root user
+        stage("Cleanup") {
+            steps {
+                sh "rm -R .gradle/ build app/build"
+            }
+        }
+    }
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-all.zip

--- a/tools/dockers/android-sdk/Dockerfile
+++ b/tools/dockers/android-sdk/Dockerfile
@@ -1,0 +1,4 @@
+FROM thyrlian/android-sdk:7.0
+WORKDIR .
+RUN /bin/bash -c '$ANDROID_SDK_ROOT/cmdline-tools/tools/bin/sdkmanager --install "build-tools;30.0.2" "sources;android-30"'
+ENV TZ="Europe/Lisbon"


### PR DESCRIPTION
* Created android-sdk Dockerfile
* Created declarative Jenkinsfile
  - Made pipeline run on android dockerfile
  - Created stage to assemble lib and some extra stage to cleanup some folders generated by the docker on the versioned code(needed because of permission issues)
* Upgraded gradle version to 7.1.1